### PR TITLE
Improve backend with JWT auth and admin routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,10 @@ integration is included.
 API endpoints are exposed under `/api`. Adjust the MongoDB connection string via
 `MONGO_URI` environment variable. Google Sheets integration requires
 `GOOGLE_KEY` (path to your service account JSON) and `SHEET_ID`.
+
+## Frontend
+
+A minimal React UI lives in `client/`. It uses CDN builds of React and
+TailwindCSS so no build step is required. Open `client/index.html` in your
+browser to try it out. The UI allows users to register, log in, mark attendance
+and, if logged in as an admin, manage user star ratings.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # new_attendance
+This is my attendance system project.
 
 A prototype attendance tracking system using **Node.js**, **Express**, and **MongoDB**.
 The project demonstrates a simple backend API for registering users, logging in,

--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
 # new_attendance
-This is my attendance system project.
+
+A prototype attendance tracking system using **Node.js**, **Express**, and **MongoDB**.
+The project demonstrates a simple backend API for registering users, logging in,
+and recording attendance. Users authenticate via JSON Web Tokens. Admin routes
+allow listing users and updating star ratings. A placeholder Google Sheets
+integration is included.
+
+## Structure
+
+- `server/`
+  - `server.js` – main Express app
+  - `config/db.js` – MongoDB connection
+  - `models/` – Mongoose models for users and attendance
+  - `routes/` – API routes for authentication, attendance, and admin actions
+  - `googleSheets.js` – stub for pushing updates to Google Sheets
+
+## Usage
+
+1. Install dependencies (requires Node.js):
+   ```sh
+   npm install
+   ```
+2. Start the server:
+   ```sh
+   node server/server.js
+   ```
+
+API endpoints are exposed under `/api`. Adjust the MongoDB connection string via
+`MONGO_URI` environment variable. Google Sheets integration requires
+`GOOGLE_KEY` (path to your service account JSON) and `SHEET_ID`.

--- a/client/app.jsx
+++ b/client/app.jsx
@@ -1,0 +1,160 @@
+const { useState, useEffect } = React;
+
+function Login({ onLogin, switchView }) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  return (
+    <div className="max-w-sm mx-auto mt-10 p-4 bg-white rounded shadow">
+      <h2 className="text-xl mb-4">Login</h2>
+      <input className="border p-2 w-full mb-2" placeholder="Email" value={email} onChange={e => setEmail(e.target.value)} />
+      <input className="border p-2 w-full mb-2" type="password" placeholder="Password" value={password} onChange={e => setPassword(e.target.value)} />
+      <button className="bg-blue-500 text-white px-4 py-2 w-full" onClick={() => onLogin(email, password)}>Login</button>
+      <p className="mt-2 text-sm text-center">
+        No account? <button className="text-blue-600" onClick={() => switchView('register')}>Register</button>
+      </p>
+    </div>
+  );
+}
+
+function Register({ onRegister, switchView }) {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  return (
+    <div className="max-w-sm mx-auto mt-10 p-4 bg-white rounded shadow">
+      <h2 className="text-xl mb-4">Register</h2>
+      <input className="border p-2 w-full mb-2" placeholder="Name" value={name} onChange={e => setName(e.target.value)} />
+      <input className="border p-2 w-full mb-2" placeholder="Email" value={email} onChange={e => setEmail(e.target.value)} />
+      <input className="border p-2 w-full mb-2" type="password" placeholder="Password" value={password} onChange={e => setPassword(e.target.value)} />
+      <button className="bg-blue-500 text-white px-4 py-2 w-full" onClick={() => onRegister(name, email, password)}>Register</button>
+      <p className="mt-2 text-sm text-center">
+        Have an account? <button className="text-blue-600" onClick={() => switchView('login')}>Login</button>
+      </p>
+    </div>
+  );
+}
+
+function Dashboard({ user, onMark, records, onRefresh }) {
+  const [status, setStatus] = useState('present');
+  return (
+    <div className="max-w-md mx-auto mt-10 p-4 bg-white rounded shadow">
+      <h2 className="text-xl mb-4">Welcome {user.name}</h2>
+      <div className="mb-4">
+        <select className="border p-2 mr-2" value={status} onChange={e => setStatus(e.target.value)}>
+          <option value="present">Present</option>
+          <option value="absent">Absent</option>
+        </select>
+        <button className="bg-green-500 text-white px-3 py-2" onClick={() => onMark(status)}>Mark Attendance</button>
+        <button className="ml-2 text-sm text-blue-600" onClick={onRefresh}>Refresh</button>
+      </div>
+      <ul>
+        {records.map(r => (
+          <li key={r._id} className="border-b py-1 text-sm flex justify-between">
+            <span>{new Date(r.date).toLocaleDateString()}</span>
+            <span>{r.status}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function AdminPanel({ token }) {
+  const [users, setUsers] = useState([]);
+  const [refresh, setRefresh] = useState(0);
+  useEffect(() => {
+    fetch('/api/admin/users', {
+      headers: { Authorization: `Bearer ${token}` }
+    })
+      .then(res => res.json())
+      .then(data => setUsers(data));
+  }, [token, refresh]);
+
+  function updateStars(id, stars) {
+    fetch(`/api/admin/users/${id}/star`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify({ stars: Number(stars) })
+    }).then(() => setRefresh(r => r + 1));
+  }
+
+  return (
+    <div className="max-w-md mx-auto mt-10 p-4 bg-white rounded shadow">
+      <h2 className="text-xl mb-4">Admin Panel</h2>
+      <ul>
+        {users.map(u => (
+          <li key={u.id} className="border-b py-2 flex items-center">
+            <span className="flex-1">{u.name} ({u.email})</span>
+            <input type="number" min="0" max="5" defaultValue={u.stars} className="border w-16 mr-2" onBlur={e => updateStars(u.id, e.target.value)} />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function App() {
+  const [view, setView] = useState('login');
+  const [token, setToken] = useState(null);
+  const [user, setUser] = useState(null);
+  const [records, setRecords] = useState([]);
+
+  function login(email, password) {
+    fetch('/api/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password })
+    }).then(res => res.json()).then(data => {
+      if (data.token) {
+        setToken(data.token);
+        setUser(data.user);
+        setView(data.user.role === 'admin' ? 'admin' : 'dashboard');
+        loadRecords(data.token);
+      }
+    });
+  }
+
+  function register(name, email, password) {
+    fetch('/api/auth/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, email, password })
+    }).then(res => res.json()).then(data => {
+      if (data.token) {
+        setToken(data.token);
+        setUser(data.user);
+        setView('dashboard');
+        loadRecords(data.token);
+      }
+    });
+  }
+
+  function loadRecords(tok = token) {
+    fetch('/api/attendance/me', { headers: { Authorization: `Bearer ${tok}` } })
+      .then(res => res.json())
+      .then(data => setRecords(data));
+  }
+
+  function markAttendance(status) {
+    fetch('/api/attendance', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify({ status })
+    }).then(() => loadRecords());
+  }
+
+  if (view === 'login') return <Login onLogin={login} switchView={setView} />;
+  if (view === 'register') return <Register onRegister={register} switchView={setView} />;
+  if (view === 'dashboard') return <Dashboard user={user} onMark={markAttendance} records={records} onRefresh={loadRecords} />;
+  if (view === 'admin') return <AdminPanel token={token} />;
+
+  return null;
+}
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Attendance App</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+    <script crossorigin src="https://unpkg.com/babel-standalone@7/babel.min.js"></script>
+  </head>
+  <body class="bg-gray-100">
+    <div id="root"></div>
+    <script type="text/babel" src="app.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "new_attendance",
+  "version": "1.0.0",
+  "description": "This is my attendance system project.",
+  "main": "index.js",
+  "scripts": {
+    "test": "node -e \"console.log(\\\"No tests yet\\\")\""
+  },
+  "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "body-parser": "^1.20.2",
+    "express": "^4.18.2",
+    "googleapis": "^128.0.0",
+    "jsonwebtoken": "^9.0.1",
+    "mongoose": "^7.6.1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/server/config/db.js
+++ b/server/config/db.js
@@ -1,0 +1,13 @@
+const mongoose = require('mongoose');
+
+const MONGO_URI = process.env.MONGO_URI || 'mongodb://localhost:27017/attendance';
+
+module.exports = function connectDB() {
+  mongoose.connect(MONGO_URI, {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+  });
+
+  const db = mongoose.connection;
+  db.on('error', console.error.bind(console, 'MongoDB connection error:'));
+};

--- a/server/googleSheets.js
+++ b/server/googleSheets.js
@@ -1,0 +1,28 @@
+// Minimal Google Sheets integration using the googleapis package.
+// Requires a service account JSON key file path in GOOGLE_KEY and the
+// spreadsheet ID in SHEET_ID environment variables.
+const { google } = require('googleapis');
+
+async function getSheetsClient() {
+  const keyPath = process.env.GOOGLE_KEY;
+  if (!keyPath) throw new Error('GOOGLE_KEY not set');
+  const auth = new google.auth.GoogleAuth({
+    keyFile: keyPath,
+    scopes: ['https://www.googleapis.com/auth/spreadsheets'],
+  });
+  return google.sheets({ version: 'v4', auth });
+}
+
+async function addAttendanceRow(email, status) {
+  const sheets = await getSheetsClient();
+  const spreadsheetId = process.env.SHEET_ID;
+  const values = [[new Date().toISOString(), email, status]];
+  await sheets.spreadsheets.values.append({
+    spreadsheetId,
+    range: 'Sheet1!A1',
+    valueInputOption: 'RAW',
+    requestBody: { values },
+  });
+}
+
+module.exports = { addAttendanceRow };

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -1,0 +1,23 @@
+const jwt = require('jsonwebtoken');
+
+const JWT_SECRET = process.env.JWT_SECRET || 'devsecret';
+
+function auth(requiredRole) {
+  return (req, res, next) => {
+    const header = req.headers.authorization;
+    if (!header) return res.status(401).json({ error: 'No token' });
+    const token = header.split(' ')[1];
+    try {
+      const payload = jwt.verify(token, JWT_SECRET);
+      if (requiredRole && payload.role !== requiredRole) {
+        return res.status(403).json({ error: 'Forbidden' });
+      }
+      req.user = payload;
+      next();
+    } catch (err) {
+      res.status(401).json({ error: 'Invalid token' });
+    }
+  };
+}
+
+module.exports = auth;

--- a/server/models/Attendance.js
+++ b/server/models/Attendance.js
@@ -1,0 +1,10 @@
+const mongoose = require('mongoose');
+const Schema = mongoose.Schema;
+
+const AttendanceSchema = new Schema({
+  user: { type: Schema.Types.ObjectId, ref: 'User' },
+  date: { type: Date, default: Date.now },
+  status: { type: String, enum: ['present', 'absent'], default: 'present' },
+});
+
+module.exports = mongoose.model('Attendance', AttendanceSchema);

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -1,0 +1,12 @@
+const mongoose = require('mongoose');
+const Schema = mongoose.Schema;
+
+const UserSchema = new Schema({
+  name: String,
+  email: { type: String, unique: true },
+  password: String,
+  role: { type: String, enum: ['user', 'admin'], default: 'user' },
+  stars: { type: Number, default: 0 },
+});
+
+module.exports = mongoose.model('User', UserSchema);

--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -1,0 +1,24 @@
+const express = require('express');
+const router = express.Router();
+const User = require('../models/User');
+const auth = require('../middleware/auth');
+
+// List all users
+router.get('/users', auth('admin'), async (req, res) => {
+  const users = await User.find();
+  res.json(users.map(u => ({ id: u._id, name: u.name, email: u.email, role: u.role, stars: u.stars })));
+});
+
+// Update a user's star rating
+router.patch('/users/:id/star', auth('admin'), async (req, res) => {
+  const { stars } = req.body;
+  try {
+    const user = await User.findByIdAndUpdate(req.params.id, { stars }, { new: true });
+    if (!user) return res.status(404).json({ error: 'User not found' });
+    res.json({ id: user._id, name: user.name, stars: user.stars });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+module.exports = router;

--- a/server/routes/attendance.js
+++ b/server/routes/attendance.js
@@ -1,0 +1,29 @@
+const express = require('express');
+const router = express.Router();
+const Attendance = require('../models/Attendance');
+const User = require('../models/User');
+const { addAttendanceRow } = require('../googleSheets');
+const auth = require('../middleware/auth');
+
+// Mark attendance and update Google Sheet
+router.post('/', auth(), async (req, res) => {
+  const { status } = req.body;
+  const userId = req.user.id;
+  try {
+    const record = await Attendance.create({ user: userId, status });
+    const user = await User.findById(userId);
+    // Push update to Google Sheet (async but don't await)
+    addAttendanceRow(user.email, status).catch(console.error);
+    res.json(record);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// Get attendance records for the logged-in user
+router.get('/me', auth(), async (req, res) => {
+  const records = await Attendance.find({ user: req.user.id }).sort({ date: -1 });
+  res.json(records);
+});
+
+module.exports = router;

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,0 +1,41 @@
+const express = require('express');
+const router = express.Router();
+const User = require('../models/User');
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+const auth = require('../middleware/auth');
+
+const JWT_SECRET = process.env.JWT_SECRET || 'devsecret';
+
+// Register
+router.post('/register', async (req, res) => {
+  const { name, email, password } = req.body;
+  const hashed = await bcrypt.hash(password, 10);
+  try {
+    const user = await User.create({ name, email, password: hashed });
+    const token = jwt.sign({ id: user._id, role: user.role }, JWT_SECRET);
+    res.json({ token, user: { id: user._id, name: user.name, email: user.email, role: user.role } });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// Login (very basic)
+router.post('/login', async (req, res) => {
+  const { email, password } = req.body;
+  const user = await User.findOne({ email });
+  if (!user) return res.status(401).json({ error: 'Invalid email' });
+  const match = await bcrypt.compare(password, user.password);
+  if (!match) return res.status(401).json({ error: 'Invalid password' });
+  const token = jwt.sign({ id: user._id, role: user.role }, JWT_SECRET);
+  res.json({ token, user: { id: user._id, name: user.name, email: user.email, role: user.role, stars: user.stars } });
+});
+
+// Get info about the logged in user
+router.get('/me', auth(), async (req, res) => {
+  const user = await User.findById(req.user.id);
+  if (!user) return res.status(404).json({ error: 'User not found' });
+  res.json({ id: user._id, name: user.name, email: user.email, role: user.role, stars: user.stars });
+});
+
+module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,19 @@
+const express = require('express');
+const mongoose = require('mongoose');
+const bodyParser = require('body-parser');
+const authRoutes = require('./routes/auth');
+const attendanceRoutes = require('./routes/attendance');
+const adminRoutes = require('./routes/admin');
+const connectDB = require('./config/db');
+
+const app = express();
+app.use(bodyParser.json());
+
+connectDB();
+
+app.use('/api/auth', authRoutes);
+app.use('/api/attendance', attendanceRoutes);
+app.use('/api/admin', adminRoutes);
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => console.log(`Server running on port ${PORT}`));


### PR DESCRIPTION
## Summary
- implement JSON Web Token authentication middleware
- extend auth routes to issue JWTs and expose a `/me` endpoint
- add admin API routes to list users and update star ratings
- require authentication for attendance routes
- integrate Google Sheets API using service account credentials
- document new environment vars and routes in README
- declare project dependencies in `package.json`

## Testing
- `npm test` *(fails: network requests blocked by environment)*

------
https://chatgpt.com/codex/tasks/task_b_686b90e01a7c832cad626b59b2e99d80